### PR TITLE
[GITHUB-11] Adds delay to reboot reconnect

### DIFF
--- a/tasks/security_updates.yml
+++ b/tasks/security_updates.yml
@@ -51,6 +51,7 @@
 
     - name: Wait for system to become reachable again
       wait_for_connection:
+        delay: 20
         timeout: 300
       when: "ansible_virtualization_type != 'docker'"
 


### PR DESCRIPTION
Without a delay Ansible can end up connecting just before the
remote machine reboots.